### PR TITLE
Fix Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,7 @@ Makefile*
 !Makefile.PL
 *blib
 META.yml
-MYMETA.yml
-MYMETA.json
+MYMETA.*
 inc/
 MANIFEST
 *.out
@@ -30,3 +29,4 @@ cover_db*
 !Build/
 !META.json
 !LICENSE
+/Build.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+skip_tags: true
+
+cache:
+  - C:\strawberry -> appveyor.yml
+
+install:
+  - if not exist "C:\strawberry" cinst strawberryperl -y
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+
+build_script:
+  - perl Build.PL
+  - Build
+
+test_script:
+  - Build test
+
+# notifications:
+# To get Github PR notifications from AppVeyor, get an auth token from Github,
+# encrypt it at https://ci.appveyor.com/tools/encrypt and put it into the
+# secure field
+#  - provider: GitHubPullRequest
+#    auth_token:
+#      secure: ...

--- a/lib/Test/Vars.pm
+++ b/lib/Test/Vars.pm
@@ -78,6 +78,9 @@ sub vars_ok {
 sub _vars_ok {
     my($result_handler, $file, $args) = @_;
 
+    # Normalize Windows paths.
+    $file =~ s{\\}{/}g;
+
     my $pipe = IO::Pipe->new;
     my $pid = fork();
     if(defined $pid){

--- a/t/03_warned.t
+++ b/t/03_warned.t
@@ -34,24 +34,25 @@ my %errors = (
 foreach my $package ( sort keys %errors ) {
     my $errors = $errors{$package};
     my $path = catfile( qw( t lib ), "$package.pm" );
+    my $unix_path = "t/lib/$package.pm";
 
     my ( $premature, @results ) = run_tests( sub { vars_ok($path) } );
     ok( !$premature, "var_ok($path) had no premature output" );
     is( scalar @results, 1, "got one result from vars_ok($path)" );
     is(
-        $results[0]{fail_diag}, "\tFailed test (t/03_warned.t at line 38)\n",
+        $results[0]{fail_diag}, "\tFailed test ($0 at line 39)\n",
         'failure message comes from inside this test file'
     );
 
     if ( @{$errors} == 1 ) {
         like(
             $results[0]{diag},
-            _error( @{ $errors->[0] }, $package, $path ),
+            _error( @{ $errors->[0] }, $package, $unix_path ),
             "expected diag() from vars_ok($path)"
         );
     }
     else {
-        my @errors = map { _error( @{$_}, $package, $path ) } @{$errors};
+        my @errors = map { _error( @{$_}, $package, $unix_path ) } @{$errors};
         like(
             $results[0]{diag},
             qr/$errors[0]$errors[1]|$errors[1]$errors[0]/,

--- a/t/05_test_vars.t
+++ b/t/05_test_vars.t
@@ -27,7 +27,7 @@ my $handler = sub {
         ]
     );
 
-    is_deeply(\@unused, [[$file, 256, \@tb_output]], 'test_vars called handler with expected results');
+    is_deeply(\@unused, [["t/lib/Warned1.pm", 256, \@tb_output]], 'test_vars called handler with expected results');
 }
 
 {

--- a/t/07_stub_sub_bug.t
+++ b/t/07_stub_sub_bug.t
@@ -26,7 +26,7 @@ use Test::Vars;
         \@unused,
         [
             [
-                $file,
+                't/lib/StubSub.pm',
                 256,
                 [
                     [


### PR DESCRIPTION
This fixes Windows in a fairly simple manner, it just normalizes the path to be Unix style.

It also adds a config for AppVeyor, CI testing for Windows.  You can turn this on at https://appveyor.com

Here's an example of it passing.
https://ci.appveyor.com/project/schwern/p5-test-vars/build/1.0.1

Fixes #21 #7 