### PR TITLE
Demonstration of regex count bug on 5.22+

### DIFF
--- a/t/lib/Regex.pm
+++ b/t/lib/Regex.pm
@@ -9,4 +9,11 @@ sub test {
     return $test =~ /blah/;
 }
 
+sub _fallback_string {
+    my $a = shift;
+    my $b = shift;
+
+    $a ? $b =~ s{test}{}gr : q{};
+}
+
 1;


### PR DESCRIPTION
This is the same problem that was fixed in some cases with PR #23. That
fix does not work with this construction for some reason.