### PR TITLE
Work around a bizarre core bug with multideref OPs in 5.22 & 5.24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,17 @@ env:
     - RELEASE_TESTING=1
     - AUTHOR_TESTING=1
 before_install:
-  - eval $(curl https://travis-perl.github.io/init) --auto
+  - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
+  - source ~/travis-perl-helpers/init
+  - build-perl
+  - perl -V
+  - build-dist
+  - cd $BUILD_DIR
+install:
+  - cpan-install --deps
+  - cpan-install --coverage
+  - cpan-install Moose Test::Output
+before_script:
+  - coverage-setup
+script:
+  - prove -l -j$(test-jobs) $(test-files)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 Revision history for Perl extension Test::Vars
 
 {{$NEXT}}
+    - Worked around a very weird bug with B's handling of multideref aux_list
+      values on 5.22 and 5.24. This could cause a warning like "Use of
+      uninitialized value $i in array element at
+      /home/autarch/projects/p5-Test-Vars/lib/Test/Vars.pm line ..." when
+      testing certain Perl constructs for unused vars. This appears to be
+      fixed in blead's B.
 
 0.012 2016-12-09T23:56:28Z
     - On Perl 5.22+, variables used in a substitution operator ($foo =~

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ install:
   - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
   - cd C:\projects\%APPVEYOR_PROJECT_NAME%
   - cpanm --installdeps . -n
+  - cpanm -n Moose Test::Output
 
 build_script:
   - perl -e 1

--- a/lib/Test/Vars.pm
+++ b/lib/Test/Vars.pm
@@ -339,6 +339,15 @@ sub _count_padvars {
         # refer to multiple pad variables.
         if($op->isa('B::UNOP_AUX')) {
             foreach my $i(grep {!ref}$ op->aux_list($cv)) {
+                # There is a bug in 5.24 with multideref aux_list where it can
+                # contain a value which is completely broken. It numifies to
+                # undef when used as an array index but "defined $i" will be
+                # true! We can detect it by comparing its stringified value to
+                # an empty string. This has been fixed in blead.
+                next unless do {
+                    no warnings;
+                    "$i" ne q{};
+                };
                 $pad[$i]{count}++
                     if $pad[$i];
             }

--- a/t/08_undef_aux_list.t
+++ b/t/08_undef_aux_list.t
@@ -1,0 +1,18 @@
+#!perl -w
+
+use strict;
+use Test::More;
+
+use Test::Vars;
+
+unless ( eval { require Test::Output; Test::Output->import; 1 } ) {
+    plan skip_all => 'This test requires Moose::Role';
+}
+
+stderr_is(
+    sub { vars_ok('t/lib/UndefAuxList.pm'); },
+    q{},
+    'no warning from 5.22 & 5.24 bug with multideref aux_list'
+);
+
+done_testing;

--- a/t/lib/UndefAuxList.pm
+++ b/t/lib/UndefAuxList.pm
@@ -1,0 +1,16 @@
+package UndefAuxList;
+
+use strict;
+use warnings;
+
+# This code comes from DateTime::Locale tools/lib/ModuleGenerator/Locale.pm -
+# it's a stripped down version that triggers a bug in multideref->aux_list
+sub _build_data_hash {
+    my $self = shift;
+
+    my $cal_root;
+    my %eraLength;
+    return $cal_root->{eras}{ 'era' . $eraLength{42} };
+}
+
+1;


### PR DESCRIPTION
The bug is fixed in blead, so we should just work around the weirdness.

@gfx - would you please review this. The bug this works around is in B.pm itself, and the value that it produces is some sort of very broken SV, because if I try to dump it with `Devel::Dwarn` I get `Bizarre copy of CODE in anonymous array ([])`. I think just detecting this issue and avoiding the warning is the best we can do.