### PR TITLE
Take into account subrefs in stashes

### DIFF
--- a/lib/Test/Vars.pm
+++ b/lib/Test/Vars.pm
@@ -169,6 +169,12 @@ sub _check_into_stash {
     foreach my $key(sort keys %{$stash}){
         my $ref = \$stash->{$key};
 
+        if (ref $$ref eq 'CODE') {
+            # reify the glob and let perl figure out what to put in GvFILE.
+            no strict 'refs';
+            () = *{B::svref_2object($stash)->NAME . "::$key"};
+        }
+
         next if ref($ref) ne 'GLOB';
 
         my $gv = B::svref_2object($ref);


### PR DESCRIPTION
From the perldelta for 5.27.6:

> =head2 Subroutines no longer need typeglobs
> 
> Perl 5.22.0 introduced an optimization allowing subroutines to be stored in
> packages as simple sub refs, not requiring a full typeglob (thus
> potentially saving large amounts of memeory).  However, the optimization
> was flawed: it only applied to the main package.
> 
> This optimization has now been extended to all packages.  This may break
> compatibility with introspection code that looks inside stashes and expects
> everything in them to be a typeglob.
> 
> When this optimization happens, the typeglob still notionally exists, so
> accessing it will cause the stash entry to be upgraded to a typeglob.  The
> optimization does not apply to XSUBs or exported subroutines, and calling a
> method will undo it, since method calls cache things in typeglobs.
> 
> [perl #129916] [perl #132252]
