### PR TITLE
Demonstrate that Perl global variables are handled properly

### DIFF
--- a/t/06_vars_ok_self.t
+++ b/t/06_vars_ok_self.t
@@ -2,11 +2,18 @@
 
 use strict;
 use Test::More;
-
 use Test::Vars;
+use File::Spec::Functions qw( catfile );
 
-vars_ok('lib/Test/Vars.pm');
+my $file;
+
+$file = catfile( qw( lib Test Vars.pm ) );
+vars_ok($file);
 vars_ok('Test::Vars');
-vars_ok('lib/Test/Vars.pm', ignore_vars => { '$self' => 1 });
+vars_ok($file, ignore_vars => { '$self' => 1 });
+
+# https://github.com/houseabsolute/p5-Test-Vars/issues/18
+$file = catfile( qw( t lib CaretVariable.pm ) );
+vars_ok($file);
 
 done_testing;

--- a/t/lib/CaretVariable.pm
+++ b/t/lib/CaretVariable.pm
@@ -1,0 +1,19 @@
+package Foo;
+use strict;
+use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(detect_os);
+
+sub detect_os {
+    if ($^O eq 'linux') {
+        print "linux\n";
+    }
+    elsif (${^O} eq 'freebsd') {
+        print "freebsd\n";
+    }
+    else {
+        print "neither linux nor freebsd\n";
+    }
+}
+
+1;


### PR DESCRIPTION
The discussion in
https://github.com/houseabsolute/p5-Test-Vars/issues/18 suggested that this problem was corrected in version 0.009.  However, I could not find any pertinent code added between tags 0.008 and 0.009.  This patch is offered to demonstrate that "caret variables" are handled properly by Test-Vars, i.e., ignored.

For: GH #18