### PR TITLE
Show problem with vars_ok() re lexicals declared outside sub def

### DIFF
--- a/t/06_vars_ok_self.t
+++ b/t/06_vars_ok_self.t
@@ -9,4 +9,10 @@ vars_ok('lib/Test/Vars.pm');
 vars_ok('Test::Vars');
 vars_ok('lib/Test/Vars.pm', ignore_vars => { '$self' => 1 });
 
+TODO: {
+    local $TODO = 'https://github.com/houseabsolute/p5-Test-Vars/issues/44';
+    my $rv = vars_ok( 't/lib/LexicalsOutsideSub.pm' );
+    ok(! $rv, "vars_ok() should tell us that 3 variables are unused");
+}
+
 done_testing;

--- a/t/lib/LexicalsOutsideSub.pm
+++ b/t/lib/LexicalsOutsideSub.pm
@@ -1,0 +1,12 @@
+package LexicalsOutsideSub;
+use strict;
+use warnings;
+
+# https://github.com/houseabsolute/p5-Test-Vars/issues/44
+
+my $scalar;
+my %hash;
+my @array;
+
+1;
+


### PR DESCRIPTION
NOTE: This patch is for research; it's not ready to be committed to master.

In https://github.com/houseabsolute/p5-Test-Vars/issues/44, it was argued that vars_ok() should have failed on a .pm file that simply declared three 'my' variables but never used them and never did anything else.  vars_ok() returns '1' (as do the previous invocations of vars_ok() in the test file) where we would have expected it to return a Perl-false value.

This patch attempts to bring that observation into the test suite in the form of a TODO test.  However, we're hampered by the fact that the return value of vars_ok() is at best opaquely documented.  What we really need is a function along the lines of:

    vars_not_expected_to_be_ok('path/to/file');